### PR TITLE
APIのAUTH処理を実装

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: mvn -f ./FreTreServer/pom.xml --batch-mode --update-snapshots verify
 
       - name: Move artifacts for upload
-        if: ${{ success() }} && github.ref == 'main'
+        if: ${{ success() }} && github.ref_name == 'main'
         run: mkdir staging && cp ./*/target/*.{jar,war} staging
 
       - name: Upload artifacts
@@ -39,7 +39,7 @@ jobs:
           name: Package
           path: staging
   call-workflow:
-    if: ${{ success() }} && github.ref == 'main'
+    if: ${{ success() }} && github.ref_name == 'main'
     needs: [build]
     uses: ./.github/workflows/cd.yml
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,15 @@ jobs:
       - name: Build with maven
         run: mvn -f ./FreTreServer/pom.xml --batch-mode --update-snapshots verify
 
+  upload-ifacts:
+    if: ${{ success() && github.event_name == 'push' && github.ref_name == 'main' }} # mainへのpush時のみ実行
+    runs-on: ubuntu-latest
+    needs: [build]
+
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Move artifacts for upload
-        if: ${{ success() }} && github.ref_name == 'main'
         run: mkdir staging && cp ./*/target/*.{jar,war} staging
 
       - name: Upload artifacts
@@ -38,8 +45,9 @@ jobs:
         with:
           name: Package
           path: staging
+
   call-workflow:
-    if: ${{ success() }} && github.ref_name == 'main'
+    if: ${{ success() && github.event_name == 'push' && github.ref_name == 'main' }} # mainへのpush時のみ実行
     needs: [build]
     uses: ./.github/workflows/cd.yml
     secrets:

--- a/FreTreApiCore/conte/scripts/deploy_payara_server.sh
+++ b/FreTreApiCore/conte/scripts/deploy_payara_server.sh
@@ -2,7 +2,7 @@
 
 # 使用方法のヘルプを表示する関数
 usage() {
-    echo "Usage: $0 [-f <war file path>] [-p <payara script file path>] [-t <app team id>] [-k <apns notification key id>] [-c <common property file path>]"
+    echo "Usage: $0 [-p <payara script file path>] [-t <app team id>] [-k <apns notification key id>] [-c <common property file path>]"
     exit 1
 }
 
@@ -12,17 +12,18 @@ BUILD_SCRIPT_FILE="build_app.sh"
 PAYARA_SERVER_SCRIPT="/opt/payara6/bin/asadmin"
 APP_TEAM_ID=null
 APNS_NOTIFICATION_KEY_ID=null
+API_AUTH=null
 DOMAIN="domain1"
 FRETRE_COMMON_PROPERTY_PATH="/opt/app/resources/common.property"
 
 # 引数をパース
-while getopts "f:p:t:k:c:" opt; do
+while getopts "p:t:k:c:a:" opt; do
   case $opt in
-    f) WAR_FILE_PATH="$OPTARG" ;;
     p) PAYARA_SERVER_SCRIPT="$OPTARG" ;;
     t) APP_TEAM_ID="$OPTARG" ;;
     k) APNS_NOTIFICATION_KEY_ID="$OPTARG" ;;
     c) FRETRE_COMMON_PROPERTY_PATH="$OPTARG" ;;
+    a) API_AUTH="$OPTARG" ;;
     *) usage ;;
   esac
 done
@@ -62,6 +63,16 @@ fi
 if [ "$FRETRE_COMMON_PROPERTY_PATH" != "null" ]; then
     echo "Setting system property: commonPropertyPath=$FRETRE_COMMON_PROPERTY_PATH"
     $PAYARA_SERVER_SCRIPT create-system-properties commonPropertyPath=$FRETRE_COMMON_PROPERTY_PATH
+fi
+
+if [ "$FRETRE_COMMON_PROPERTY_PATH" != "null" ]; then
+    echo "Setting system property: commonPropertyPath=$FRETRE_COMMON_PROPERTY_PATH"
+    $PAYARA_SERVER_SCRIPT create-system-properties commonPropertyPath=$FRETRE_COMMON_PROPERTY_PATH
+fi
+
+if [ "$API_AUTH" != "null" ]; then
+    echo "Setting system property: apiAuth=$API_AUTH"
+    $PAYARA_SERVER_SCRIPT create-system-properties apiAuth=$API_AUTH
 fi
 
 # システムプロパティの確認

--- a/FreTreApiCore/src/main/java/org/stotic/dev/com/api/exception/ApiResultCode.java
+++ b/FreTreApiCore/src/main/java/org/stotic/dev/com/api/exception/ApiResultCode.java
@@ -7,6 +7,10 @@ public enum ApiResultCode {
      */
     BAD_REQUEST("000", "Received invalid request."),
     /**
+     *
+     */
+    NOT_AUTHRIZATION("001", "Not found auth."),
+    /**
      * 想定外のエラーが発生した場合
      */
     SYSTEM_ERROR("100", "Occurred System Exception"),

--- a/FreTreApiCore/src/main/java/org/stotic/dev/com/api/provider/ApiAuthFilter.java
+++ b/FreTreApiCore/src/main/java/org/stotic/dev/com/api/provider/ApiAuthFilter.java
@@ -1,0 +1,50 @@
+package org.stotic.dev.com.api.provider;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+import org.stotic.dev.com.api.exception.ApiResultCode;
+import org.stotic.dev.com.dto.ApiResultDto;
+import org.stotic.dev.com.exception.SystemException;
+import org.stotic.dev.com.logger.ApiLogger;
+import org.stotic.dev.com.model.property.SystemPropertyKey;
+import org.stotic.dev.com.utilities.SystemVariableUtility;
+
+import java.io.IOException;
+
+@PreMatching
+@Provider
+public class ApiAuthFilter implements ContainerRequestFilter {
+
+    private static final String AUTH_HEADER_KEY = "authenticate";
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+        ApiLogger.log.info("[In]");
+        String auth = containerRequestContext.getHeaderString(AUTH_HEADER_KEY);
+        try {
+            if(validateAuth(auth)) { return; }
+            ApiLogger.log.info(String.format("NOT AUTHORIZATION: $s.", auth));
+            containerRequestContext.abortWith(createAbortResponse(ApiResultCode.NOT_AUTHRIZATION));
+        } catch (SystemException e) {
+            containerRequestContext.abortWith(createAbortResponse(ApiResultCode.SYSTEM_ERROR));
+        }
+    }
+
+    private boolean validateAuth(String auth) throws SystemException {
+        if(auth == null) { return false; }
+        String originalAuth = SystemVariableUtility.getValue(SystemPropertyKey.API_AUTH);
+        return auth.equals(originalAuth);
+    }
+
+    private Response createAbortResponse(ApiResultCode code) {
+        return Response
+                .status(Response.Status.UNAUTHORIZED)
+                .type(MediaType.APPLICATION_JSON)
+                .entity(new ApiResultDto(code.getCode()))
+                .build();
+    }
+}

--- a/FreTreApiCore/src/main/java/org/stotic/dev/com/api/provider/ApiServiceExceptionHandler.java
+++ b/FreTreApiCore/src/main/java/org/stotic/dev/com/api/provider/ApiServiceExceptionHandler.java
@@ -2,15 +2,17 @@ package org.stotic.dev.com.api.provider;
 
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 import org.stotic.dev.com.api.exception.ApiServiceException;
 import org.stotic.dev.com.dto.ApiResultDto;
 import org.stotic.dev.com.logger.ApiLogger;
 
+@Provider
 public class ApiServiceExceptionHandler implements ExceptionMapper<ApiServiceException> {
 
     @Override
     public Response toResponse(ApiServiceException e) {
-        ApiLogger.log.error(e.toString());
+        ApiLogger.log.error(String.format("[In] %s", e.toString()));
         return Response.status(Response.Status.NOT_ACCEPTABLE)
                 .entity(new ApiResultDto(e.getResultCode().getCode()))
                 .build();

--- a/FreTreApiCore/src/main/java/org/stotic/dev/com/api/provider/BadRequestExceptionHandler.java
+++ b/FreTreApiCore/src/main/java/org/stotic/dev/com/api/provider/BadRequestExceptionHandler.java
@@ -12,7 +12,7 @@ public class BadRequestExceptionHandler implements ExceptionMapper<NullPointerEx
 
     @Override
     public Response toResponse(NullPointerException e) {
-        ApiLogger.log.error(e.toString());
+        ApiLogger.log.error(String.format("[In] %s", e.toString()));
         return Response.status(Response.Status.BAD_REQUEST)
                 .entity(new ApiResultDto(ApiResultCode.BAD_REQUEST.getCode()))
                 .build();

--- a/FreTreApiCore/src/main/java/org/stotic/dev/com/api/provider/SystemExceptionHandler.java
+++ b/FreTreApiCore/src/main/java/org/stotic/dev/com/api/provider/SystemExceptionHandler.java
@@ -2,16 +2,18 @@ package org.stotic.dev.com.api.provider;
 
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 import org.stotic.dev.com.api.exception.ApiResultCode;
 import org.stotic.dev.com.exception.SystemException;
 import org.stotic.dev.com.dto.ApiResultDto;
 import org.stotic.dev.com.logger.ApiLogger;
 
+@Provider
 public class SystemExceptionHandler implements ExceptionMapper<SystemException> {
 
     @Override
     public Response toResponse(SystemException e) {
-        ApiLogger.log.error(e.toString());
+        ApiLogger.log.error(String.format("[In] %s", e.toString()));
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                 .entity(new ApiResultDto(ApiResultCode.SYSTEM_ERROR.getCode()))
                 .build();

--- a/FreTreApiCore/src/main/java/org/stotic/dev/com/model/property/SystemPropertyKey.java
+++ b/FreTreApiCore/src/main/java/org/stotic/dev/com/model/property/SystemPropertyKey.java
@@ -15,7 +15,8 @@ public enum SystemPropertyKey implements SystemVariableKeys {
     /**
      * 共通プロパティファイルのパス
      */
-    COMMON_PROPERTY_PATH("commonPropertyPath");
+    COMMON_PROPERTY_PATH("commonPropertyPath"),
+    API_AUTH("apiAuth");
 
     SystemPropertyKey(String key) {
         this.key = key;


### PR DESCRIPTION
# 概要
APIを特定のアプリからのみ実行できるように、AUTH処理を実装する

# 内容
JAX-RSのPreMatchのFilterを実装し、そこでauthヘッダーの検証を行い検証に誤りがあれば認証失敗でレスポンスを返すようにする