### PR TITLE
[1.0] [bugfix] 短期間に複数のPush通知送信リクエストを受けるとAPNSから429エラーが返される

### DIFF
--- a/FreTreApiCore/src/main/java/org/stotic/dev/com/logic/SendNotificationLogic.java
+++ b/FreTreApiCore/src/main/java/org/stotic/dev/com/logic/SendNotificationLogic.java
@@ -8,16 +8,13 @@ import org.stotic.dev.com.exception.SystemException;
 import org.stotic.dev.com.dto.SendNotificationReq;
 import org.stotic.dev.com.logger.ApiLogger;
 import org.stotic.dev.com.model.*;
-import org.stotic.dev.com.model.privateKey.ApnsPushNotificationPrivateKeyAccessor;
+import org.stotic.dev.com.model.jwt.ApnsTokenRepository;
 import org.stotic.dev.com.model.property.CommonPropertyKey;
 import org.stotic.dev.com.model.property.CommonPropertyReader;
-import org.stotic.dev.com.model.property.SystemPropertyKey;
 import org.stotic.dev.com.model.restClient.ApnsPushNotificationClient;
 import org.stotic.dev.com.model.restClient.service.ApnsPushNotificationHttpService;
 import org.stotic.dev.com.model.uuid.UuidGenerator;
-import org.stotic.dev.com.utilities.SystemVariableUtility;
 
-import java.security.PrivateKey;
 import java.util.UUID;
 
 @ApplicationScoped
@@ -25,6 +22,8 @@ public class SendNotificationLogic implements ApiLogic<SendNotificationReq, Send
 
     @Inject
     private CommonPropertyReader propertyReader;
+    @Inject
+    private ApnsTokenRepository apnsTokenRepository;
     @Inject
     private UuidGenerator uuid;
     @Inject
@@ -56,11 +55,7 @@ public class SendNotificationLogic implements ApiLogic<SendNotificationReq, Send
 
     private PushNotificationApnsRequestHeader createApnsRequestHeader(SendNotificationReq req) throws SystemException {
         // Apnsへリクエストするための認証トークンを作成
-        ApnsPushNotificationPrivateKeyAccessor accessor = new ApnsPushNotificationPrivateKeyAccessor(propertyReader.getValue(CommonPropertyKey.APNS_PRIVATE_KEY_PATH));
-        PrivateKey privateKey = accessor.getPrivateKey();
-        String teamId = SystemVariableUtility.getValue(SystemPropertyKey.APP_TEAM_ID);
-        String keyId = SystemVariableUtility.getValue(SystemPropertyKey.APNS_KEY_ID);
-        PushNotificationApnsAuthorization authorization = new PushNotificationApnsAuthorization(privateKey, teamId, keyId);
+        PushNotificationApnsAuthorization authorization = apnsTokenRepository.build();
 
         // Apnsへリクエストするための通知タイプを指定
         PushNotificationType pushType = PushNotificationType.ALERT;

--- a/FreTreApiCore/src/main/java/org/stotic/dev/com/model/jwt/ApnsTokenRepository.java
+++ b/FreTreApiCore/src/main/java/org/stotic/dev/com/model/jwt/ApnsTokenRepository.java
@@ -1,0 +1,62 @@
+package org.stotic.dev.com.model.jwt;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.stotic.dev.com.exception.SystemException;
+import org.stotic.dev.com.logger.ApiLogger;
+import org.stotic.dev.com.model.PushNotificationApnsAuthorization;
+import org.stotic.dev.com.model.privateKey.ApnsPushNotificationPrivateKeyAccessor;
+import org.stotic.dev.com.model.property.CommonPropertyKey;
+import org.stotic.dev.com.model.property.CommonPropertyReader;
+import org.stotic.dev.com.model.property.SystemPropertyKey;
+import org.stotic.dev.com.utilities.SystemVariableUtility;
+
+import java.security.PrivateKey;
+import java.time.Instant;
+
+@ApplicationScoped
+public class ApnsTokenRepository {
+
+    // 現在保持しているJWT
+    private PushNotificationApnsAuthorization apnsAuthorization;
+    // JWT更新時間
+    private Instant updateTime;
+
+    // JWT保持期間(秒)
+    private static final Long TOKEN_RETENTION_PERIOD = (long) (60 * 50);
+
+    @Inject
+    private CommonPropertyReader propertyReader;
+
+    public ApnsTokenRepository() {
+        updateTime = Instant.ofEpochSecond(0);
+    }
+
+    /**
+     * Apnsの認証トークンを返す
+     * 認証トークンは生成してから50分保持し50分間は保持しているトークンを返す
+     * 50分経過している場合は再度新しいトークンを発行して返す
+     *
+     * @return PushNotificationApnsAuthorization: 認証トークン
+     * @throws SystemException
+     */
+    public PushNotificationApnsAuthorization build() throws SystemException {
+        Instant now = Instant.now();
+        if((now.getEpochSecond() - updateTime.getEpochSecond()) >=TOKEN_RETENTION_PERIOD) {
+            ApiLogger.log.info(String.format("Necessary update authorization token(prevUpdate=%s, now=%s)", updateTime, now));
+            this.apnsAuthorization = generateAuthorization();
+            this.updateTime = now;
+        }
+
+        return this.apnsAuthorization;
+    }
+
+    private PushNotificationApnsAuthorization generateAuthorization() throws SystemException {
+        // Apnsへリクエストするための認証トークンを作成
+        ApnsPushNotificationPrivateKeyAccessor accessor = new ApnsPushNotificationPrivateKeyAccessor(propertyReader.getValue(CommonPropertyKey.APNS_PRIVATE_KEY_PATH));
+        PrivateKey privateKey = accessor.getPrivateKey();
+        String teamId = SystemVariableUtility.getValue(SystemPropertyKey.APP_TEAM_ID);
+        String keyId = SystemVariableUtility.getValue(SystemPropertyKey.APNS_KEY_ID);
+        return new PushNotificationApnsAuthorization(privateKey, teamId, keyId);
+    }
+}

--- a/FreTreApiCore/src/main/resources/common.property
+++ b/FreTreApiCore/src/main/resources/common.property
@@ -9,6 +9,6 @@ app.bundle.id=com.TacihiSato.FreTre
 
 # ApnsPushNotification .p8ファイルのファイルパス
 # ローカル
-# apns.private.key.path=/Users/satoutaichi/work/key/iOS証明書/ServiceKeys/PushNotificationService/AuthKey_PC6F4BA63U.p8
+apns.private.key.path=/Users/satoutaichi/work/key/iOS証明書/ServiceKeys/PushNotificationService/AuthKey_PC6F4BA63U.p8
 # サーバー
-apns.private.key.path=/home/taichis844/.PrivateKey/AuthKey_PC6F4BA63U.p8
+#apns.private.key.path=/home/taichis844/.PrivateKey/AuthKey_PC6F4BA63U.p8

--- a/PushNotificationCore/src/main/java/org/stotic/dev/com/model/PushNotificationApnsAuthorization.java
+++ b/PushNotificationCore/src/main/java/org/stotic/dev/com/model/PushNotificationApnsAuthorization.java
@@ -12,30 +12,21 @@ import java.security.SignatureException;
 
 public class PushNotificationApnsAuthorization {
 
-    private PrivateKey privateKey;
-    private String teamId;
-    private String keyId;
+    private final String authorizationToken;
 
-    public PushNotificationApnsAuthorization(PrivateKey privateKey, String teamId, String keyId) {
-        this.privateKey = privateKey;
-        this.teamId = teamId;
-        this.keyId = keyId;
-        ApiLogger.log.info(String.format("Complete initialize PushNotificationApnsAuthorization(privateKey=%s, teamId=%s, keyId=%s)", privateKey.toString(), teamId, keyId));
-    }
-
-    public String getAuthorizationToken() throws SystemException {
+    public PushNotificationApnsAuthorization(PrivateKey privateKey, String teamId, String keyId) throws SystemException {
         try {
             String jwtToken = JwtGenerator.generateJwtToken(privateKey, keyId, teamId);
             ApiLogger.log.debug("Succeed generate jwt token.");
-            return String.format("Bearer %s", jwtToken);
-        } catch (NoSuchAlgorithmException e) {
-            throw new SystemException(e.toString());
-        } catch (SignatureException e) {
-            throw new SystemException(e.toString());
-        } catch (InvalidKeyException e) {
-            throw new SystemException(e.toString());
-        } catch (JsonProcessingException e) {
+            authorizationToken = String.format("Bearer %s", jwtToken);
+        } catch (NoSuchAlgorithmException | SignatureException | JsonProcessingException | InvalidKeyException e) {
             throw new SystemException(e.toString());
         }
+
+        ApiLogger.log.info(String.format("Complete initialize PushNotificationApnsAuthorization(privateKey=%s, teamId=%s, keyId=%s)", privateKey.toString(), teamId, keyId));
+    }
+
+    public String getAuthorizationToken() {
+        return this.authorizationToken;
     }
 }


### PR DESCRIPTION
# 目的
短期間に複数のPush通知送信リクエストを受けるとAPNSから429エラー(TooManyProviderTokenUpdates)が返される。
この問題の対応の修正を行う。

# 原因
以下より、頻繁にJWTの更新を行うと発生する。
https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW1

# 修正内容
一度生成したJWTの生存期間を50分として、JWTを使い回すようにする。
JWTを生成して50分以上経過した場合、新たにJWTを生成するようにする。

50分とした根拠として、下記記事よりJWTの生存期間の最大値は1時間のため10分のマージンをとって50分とした。
https://developer.apple.com/documentation/usernotifications/establishing-a-token-based-connection-to-apns